### PR TITLE
Fix conversion issues in Rails 5.1

### DIFF
--- a/lib/active_record-mysql-uuid_column/type_class.rb
+++ b/lib/active_record-mysql-uuid_column/type_class.rb
@@ -30,7 +30,7 @@ module ActiveRecord
       def assert_valid_value(value)
         case value.class
         when String, ActiveSupport::ToJsonWithActiveSupportEncoder
-          if value.downcase.gsub(/[^a-f0-9]/, '').size == 32
+          if value.to_s.downcase.gsub(/[^a-f0-9]/, '').size == 32
             value
           else
             raise SerializationTypeMismatch,

--- a/lib/active_record-mysql-uuid_column/type_class.rb
+++ b/lib/active_record-mysql-uuid_column/type_class.rb
@@ -52,6 +52,8 @@ module ActiveRecord
         end
 
         def self.from_database(value)
+          return value if value.is_a? Data
+
           storage_format = value.unpack('H*').first.rjust(32, '0')
           new(
             storage_format.gsub(/^(.{8})(.{4})(.{4})(.{4})(.{12})$/, '\1-\2-\3-\4-\5'),

--- a/lib/active_record-mysql-uuid_column/type_class.rb
+++ b/lib/active_record-mysql-uuid_column/type_class.rb
@@ -30,11 +30,11 @@ module ActiveRecord
       def assert_valid_value(value)
         case value.class
         when String, ActiveSupport::ToJsonWithActiveSupportEncoder
-          if value.to_s.downcase.gsub(/[^a-f0-9]/, '').size == 32
+          if value.blank? || value.to_s.downcase.gsub(/[^a-f0-9]/, '').size == 32
             value
           else
             raise SerializationTypeMismatch,
-              "Invalid String uuid #{value}."
+              "Invalid String uuid '#{value}'"
           end
         else
           raise SerializationTypeMismatch,
@@ -48,6 +48,7 @@ module ActiveRecord
         end
 
         def self.from_uuid_string(uuid)
+          return nil if uuid.nil?
           new(uuid, uuid.downcase.gsub(/[^a-f0-9]/, ''))
         end
 


### PR DESCRIPTION
I'm attempting to use this gem in a Rails 5.1 project (brand new!) and bumped into a couple of conversion issues. To be honest, I didn't look too deep into why these two methods (`assert_valid_value` and `from_database`) are receiving instances of `ActiveRecord::Type::Uuid::Data`, but these changes make it work.

Any feedback greatly appreciated!